### PR TITLE
fix(go): rename AttToBeSigned to match spec

### DIFF
--- a/go/cmd/passkey-verify/passkey-verify.go
+++ b/go/cmd/passkey-verify/passkey-verify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"flag"
 	"fmt"
 	"log"
@@ -121,9 +122,10 @@ func main() {
 
 		// TODO decode CBOR data
 
+		message := sha256.Sum256(assertion.Response.AttToBeSigned)
 		verified := ecdsa.VerifyASN1(
 			registration.Response.PublicKeyECDSA,
-			assertion.Response.VerifiableBytes,
+			message[:],
 			assertion.Response.Signature,
 		)
 		if !verified {

--- a/go/passkey/passkey.go
+++ b/go/passkey/passkey.go
@@ -103,7 +103,7 @@ type Assertion struct {
 		ClientDataJSON       RawURLBase64       `json:"clientDataJSON"`
 		ClientData           ClientData         `json:"-"`
 		Signature            RawURLBase64       `json:"signature"`
-		VerifiableBytes      []byte             `json:"-"`
+		AttToBeSigned        []byte             `json:"-"`
 	} `json:"response"`
 }
 
@@ -118,10 +118,7 @@ func ParseAssertion(credentialRequestResponse []byte) (*Assertion, error) {
 	}
 
 	clientDataHash := sha256.Sum256(credReq.Response.ClientDataJSON)
-	verifiableData := append(credReq.Response.AuthenticatorDataRaw, clientDataHash[:]...)
-	// each algo specifies the SHA-xxx hash in its name
-	// exception: SHA512 used for EDDSA
-	verifiableHash := sha256.Sum256(verifiableData)
+	attToBeSigned := append(credReq.Response.AuthenticatorDataRaw, clientDataHash[:]...)
 
 	var err error
 	credReq.Response.AuthenticatorData, err = ParseAuthenticatorData(credReq.Response.AuthenticatorDataRaw)
@@ -129,7 +126,7 @@ func ParseAssertion(credentialRequestResponse []byte) (*Assertion, error) {
 		return nil, err
 	}
 
-	credReq.Response.VerifiableBytes = verifiableHash[:]
+	credReq.Response.AttToBeSigned = attToBeSigned
 
 	return credReq, nil
 }


### PR DESCRIPTION
> Concatenate _authenticatorData_ and _clientDataHash_ to form _attToBeSigned_. - https://w3c.github.io/webauthn/#sctn-op-get-assertion

_attToBeSigned_ is referenced only in the context of attestation - not verification - however _authenticatorDataAndClientDataHash_ doesn't quite roll off the tongue, and _verifiableBytes_ is vague, so _attToBeSigned_ seems like the best possible choice.